### PR TITLE
Remove offending call to `this(null)` in default Response constructor

### DIFF
--- a/src/main/java/com/twilio/survey/models/Response.java
+++ b/src/main/java/com/twilio/survey/models/Response.java
@@ -25,7 +25,6 @@ public class Response {
   }
 
   public Response() {
-    this(null);
   }
 
   // Accessors


### PR DESCRIPTION
I believe I've located what was preventing a successful build in #6, and removed it. `mvn test` and `mvn install` completed on my machine (and in a Heroku deployment) without error. 

Let me know if you have any questions, or if there's any other changes you'd like to make as part of this pull request.

Thanks, all!
